### PR TITLE
추가: 카드 관련 컴포넌트(카드, 카드리스트, 해시태그 칩 배열) 생성

### DIFF
--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Typography from "@mui/material/Typography";
+// import TagArray from "./TagArray";
+
+const ProductCard = ({ image, alt, title, description, tags }) => (
+  <Card sx={{ maxWidth: 345 }}>
+    <CardMedia component="img" alt={alt} height="140" image={image} />
+    <CardContent>
+      <Typography gutterBottom variant="h5" component="div">
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {description}
+      </Typography>
+    </CardContent>
+    {/* <TagArray tags={tags} /> */}
+  </Card>
+);
+
+ProductCard.defaultProps = {
+  image: "https://via.placeholder.com/345x140",
+  alt: "비어있는 이미지",
+  title: "프로젝트 제목",
+  description: "설명",
+  tags: ["개발", "React"],
+};
+
+export default ProductCard;

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -6,8 +6,8 @@ import Typography from "@mui/material/Typography";
 import TagArray from "./TagArray";
 
 const ProductCard = ({ image, alt, title, description, tags }) => (
-  <Card sx={{ maxWidth: 345 }}>
-    <CardMedia component="img" alt={alt} height="140" image={image} />
+  <Card sx={{ maxWidth: 345, borderRadius: "15px" }}>
+    <CardMedia component="img" alt={alt} height="200" image={image} />
     <CardContent>
       <Typography gutterBottom variant="h5" component="div">
         {title}
@@ -21,7 +21,7 @@ const ProductCard = ({ image, alt, title, description, tags }) => (
 );
 
 ProductCard.defaultProps = {
-  image: "https://via.placeholder.com/345x140",
+  image: "https://via.placeholder.com/345x200",
   alt: "비어있는 이미지",
   title: "프로젝트 제목",
   description: "설명",

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -3,7 +3,7 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
 import Typography from "@mui/material/Typography";
-// import TagArray from "./TagArray";
+import TagArray from "./TagArray";
 
 const ProductCard = ({ image, alt, title, description, tags }) => (
   <Card sx={{ maxWidth: 345 }}>
@@ -16,7 +16,7 @@ const ProductCard = ({ image, alt, title, description, tags }) => (
         {description}
       </Typography>
     </CardContent>
-    {/* <TagArray tags={tags} /> */}
+    <TagArray tags={tags} />
   </Card>
 );
 
@@ -25,7 +25,18 @@ ProductCard.defaultProps = {
   alt: "비어있는 이미지",
   title: "프로젝트 제목",
   description: "설명",
-  tags: ["개발", "React"],
+  tags: [
+    {
+      key: 0,
+      label: "태그1",
+      href: "#",
+    },
+    {
+      key: 1,
+      label: "태그2",
+      href: "#",
+    },
+  ],
 };
 
 export default ProductCard;

--- a/src/components/ProductCardList.jsx
+++ b/src/components/ProductCardList.jsx
@@ -39,7 +39,7 @@ const ProductCardList = ({ cardData }) => (
 ProductCardList.defaultProps = {
   cardData: [
     {
-      image: "https://via.placeholder.com/345x140",
+      image: "https://via.placeholder.com/345x200",
       alt: "비어있는 이미지",
       title: "프로젝트 제목",
       description: "설명",
@@ -57,7 +57,7 @@ ProductCardList.defaultProps = {
       ],
     },
     {
-      image: "https://via.placeholder.com/345x140",
+      image: "https://via.placeholder.com/345x200",
       alt: "비어있는 이미지",
       title: "프로젝트 제목",
       description: "설명",

--- a/src/components/ProductCardList.jsx
+++ b/src/components/ProductCardList.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { styled } from "@mui/material/styles";
+import Paper from "@mui/material/Paper";
+import ProductCard from "./ProductCard";
+
+const ListItem = styled("li")(({ theme }) => ({
+  margin: theme.spacing(0.8),
+}));
+
+const ProductCardList = ({ cardData }) => (
+  <Paper
+    elevation={0}
+    sx={{
+      display: "flex",
+      flexWrap: "wrap",
+      listStyle: "none",
+      p: 0.5,
+      m: 0,
+    }}
+    component="ul"
+  >
+    {cardData.map((data) => {
+      return (
+        <ListItem key={data.key}>
+          {console.log(data.key)}
+          <ProductCard
+            image={data.image}
+            alt={data.alt}
+            title={data.title}
+            description={data.description}
+            tags={data.tags}
+          />
+        </ListItem>
+      );
+    })}
+  </Paper>
+);
+
+ProductCardList.defaultProps = {
+  cardData: [
+    {
+      image: "https://via.placeholder.com/345x140",
+      alt: "비어있는 이미지",
+      title: "프로젝트 제목",
+      description: "설명",
+      tags: [
+        {
+          key: 0,
+          label: "태그1",
+          href: "#",
+        },
+        {
+          key: 1,
+          label: "태그2",
+          href: "#",
+        },
+      ],
+    },
+    {
+      image: "https://via.placeholder.com/345x140",
+      alt: "비어있는 이미지",
+      title: "프로젝트 제목",
+      description: "설명",
+      tags: [
+        {
+          key: 0,
+          label: "태그1",
+          href: "#",
+        },
+        {
+          key: 1,
+          label: "태그2",
+          href: "#",
+        },
+      ],
+    },
+  ],
+};
+
+export default ProductCardList;

--- a/src/components/TagArray.jsx
+++ b/src/components/TagArray.jsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { styled } from "@mui/material/styles";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+
+const ListItem = styled("li")(({ theme }) => ({
+  margin: theme.spacing(0.5),
+}));
+
+const TagArray = ({ tags }) => (
+  <Paper
+    sx={{
+      display: "flex",
+      flexWrap: "wrap",
+      listStyle: "none",
+      p: 0.5,
+      m: 0,
+    }}
+    component="ul"
+  >
+    {tags.map((data) => {
+      // data : { key: 0, label: "Angular", href: "src" },
+      return (
+        <ListItem key={data.key}>
+          {console.log(data.key)}
+          <Chip label={data.label} component="a" href={data.href} clickable />
+        </ListItem>
+      );
+    })}
+  </Paper>
+);
+
+TagArray.defaultProps = {
+  tags: [
+    {
+      key: 0,
+      label: "태그1",
+      href: "#",
+    },
+    {
+      key: 1,
+      label: "태그2",
+      href: "#",
+    },
+  ],
+};
+
+export default TagArray;


### PR DESCRIPTION
## 작업내용
Issue: #2 
- 프로젝트 카드(ProductCard)
- 프로젝트 카드 리스트(ProductCardList)
- 프로젝트 해시태그 Chip Array (TagArray) 
세 개의 UI 컴포넌트를 생성했습니다.

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?