### PR TITLE
추가: recoilState 도입

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15192,7 +15192,14 @@
         }
       }
     },
-<<<<<<< HEAD
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-slick": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
@@ -15207,14 +15214,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-=======
-    "node_modules/react-scripts/node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
->>>>>>> origin
       }
     },
     "node_modules/react-transition-group": {
@@ -16912,15 +16911,9 @@
       }
     },
     "node_modules/typescript": {
-<<<<<<< HEAD
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-=======
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
->>>>>>> origin
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -30014,15 +30007,9 @@
       }
     },
     "typescript": {
-<<<<<<< HEAD
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-=======
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
->>>>>>> origin
       "peer": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,13 @@
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "react-slick": "^0.29.0",
+        "recoil": "^0.7.6",
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/uuid": "^8.3.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4804,6 +4808,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
     "node_modules/@types/ws": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -9252,6 +9262,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -15261,6 +15276,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -21303,6 +21337,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -24551,6 +24591,11 @@
       "requires": {
         "duplexer": "^0.1.2"
       }
+    },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -28774,6 +28819,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "react-slick": "^0.29.0",
+    "recoil": "^0.7.6",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"
@@ -50,5 +51,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/uuid": "^8.3.4"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 import './App.css';
 import Routes from './pages/Routes';
@@ -6,12 +8,16 @@ import theme from './styles/theme';
 
 function App() {
     return (
-        <ThemeProvider theme={theme.light}>
-            <GlobalStyles />
-            <div className="App">
-                <Routes />
-            </div>
-        </ThemeProvider>
+        <RecoilRoot>
+            <Suspense fallback={<div>Loading...</div>}>
+                <ThemeProvider theme={theme.light}>
+                    <GlobalStyles />
+                    <div className="App">
+                        <Routes />
+                    </div>
+                </ThemeProvider>
+            </Suspense>
+        </RecoilRoot>
     );
 }
 

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -1,0 +1,20 @@
+import { atom, selector } from 'recoil';
+import axios from 'axios';
+
+export const articleAtom = atom({
+    key: 'articleAtom',
+    default: {
+        articles: [],
+    },
+});
+
+export const articleSelector = selector({
+    key: 'articleSelector',
+    get: async ({ get }) => {
+        const { data } = await getArticles();
+        return data;
+    },
+    set: ({ set }) => {
+        // set(forceReloadBoardListState, Math.random());
+    },
+});

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -1,20 +1,27 @@
 import { atom, selector } from 'recoil';
-import axios from 'axios';
+import { v1 } from 'uuid';
+import { getArticles } from '../api/article';
 
 export const articleAtom = atom({
-    key: 'articleAtom',
+    key: `articleAtom/${v1()}`,
     default: {
         articles: [],
     },
 });
 
+export const filteredArticlesAtom = atom({
+    key: `filteredArticlesAtom/${v1()}`,
+    default: {
+        keyword: null,
+        articles: [],
+    },
+});
+
 export const articleSelector = selector({
-    key: 'articleSelector',
+    key: `articleSelector/${v1()}`,
     get: async ({ get }) => {
         const { data } = await getArticles();
+        console.log('selector is called');
         return data;
-    },
-    set: ({ set }) => {
-        // set(forceReloadBoardListState, Math.random());
     },
 });

--- a/src/atom/userAtom.js
+++ b/src/atom/userAtom.js
@@ -1,0 +1,23 @@
+import { atom, selector } from 'recoil';
+
+const userAtom =
+    atom <
+    userAtomType >
+    {
+        key: 'userAtom',
+        default: {
+            likeCount: 0,
+            storeName: '',
+        },
+    };
+
+const userSelector = selector({
+    key: 'userSelector',
+    get: ({ get }) => {
+        const { storeName } = get(userAtom);
+        const data = storeName;
+        return data;
+    },
+});
+
+export { userSelector, userAtom };

--- a/src/components/search/StyledForm.jsx
+++ b/src/components/search/StyledForm.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const StyledForm = ({ children }) => <StyledFrom_>{children}</StyledFrom_>;
+const StyledForm = (props) => {
+    const transformedProps = { ...props };
+    delete transformedProps.children;
+    return <StyledForm_ {...transformedProps}>{props.children}</StyledForm_>;
+};
 
-const StyledFrom_ = styled.form`
+const StyledForm_ = styled.form`
     width: 350px;
     border-radius: 30px;
     .MuiFormControl-root,

--- a/src/pages/ArchivePage.jsx
+++ b/src/pages/ArchivePage.jsx
@@ -1,54 +1,34 @@
-import React, { useEffect, useState } from 'react';
-import { getArticles } from '../api/article';
+import React from 'react';
 import PageTemplate from '../template/PageTemplate';
 import SearchForm from '../components/search/SearchForm';
 import BannerCarousel, {
     itemsForArchivePage,
 } from '../components/BannerCarousel';
 import ListWithTabs from '../components/ListWithTabs';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { articleSelector, filteredArticlesAtom } from '../atom/articleAtom.js';
 
 const ArchivePage = (props) => {
-    const [articles, setArticles] = useState({
-        articles: [],
-        filteredArticles: [],
-        searchWord: null,
-    });
-
-    useEffect(() => {
-        (async function fetchData() {
-            const fetchedArticles = await getArticles();
-            setArticles((oldArticles) => {
-                const newArticles = {
-                    ...oldArticles,
-                    articles: fetchedArticles.data,
-                };
-                return newArticles;
-            });
-        })();
-    }, [setArticles]);
+    const articles = useRecoilValue(articleSelector);
+    const [filteredArticles, setFilteredArticles] =
+        useRecoilState(filteredArticlesAtom);
 
     const handleSubmitInput = (newInputValue) => {
-        const filteredArticles = articles.articles.filter(({ title }) =>
+        const filteredArticles = articles.filter(({ title }) =>
             title.includes(newInputValue)
         );
         if (newInputValue && newInputValue.trim() !== '') {
-            setArticles((oldArticles) => {
-                const newArticles = {
-                    ...oldArticles,
-                    filteredArticles: filteredArticles,
-                    searchWord: newInputValue,
-                };
-                return newArticles;
-            });
+            setFilteredArticles((oldState) => ({
+                ...oldState,
+                keyword: newInputValue,
+                articles: filteredArticles,
+            }));
         } else {
-            setArticles((oldArticles) => {
-                const newArticles = {
-                    ...oldArticles,
-                    filteredArticles: [],
-                    searchWord: '',
-                };
-                return newArticles;
-            });
+            setFilteredArticles((oldState) => ({
+                ...oldState,
+                keyword: null,
+                articles: [],
+            }));
         }
     };
 
@@ -57,31 +37,21 @@ const ArchivePage = (props) => {
          * @TODO
          * 태그 검색 구현 필요함
          */
-        const filteredArticles = articles.articles.filter(({ hashtagList }) => {
+        const filteredArticles = articles.filter(({ hashtagList }) => {
             newTagList.forEach((tag) => {
                 if (!hashtagList.includes(tag)) {
-                    console.log('포함하지 않음');
                     return false;
                 }
             });
             return true;
         });
         if (filteredArticles.length === 0) {
-            setArticles((oldArticles) => {
-                const newArticles = {
-                    ...oldArticles,
-                    filteredArticles: [],
-                };
-                return newArticles;
-            });
+            setFilteredArticles((oldState) => ({ ...oldState, articles: [] }));
         } else {
-            setArticles((oldArticles) => {
-                const newArticles = {
-                    ...oldArticles,
-                    filteredArticles: filteredArticles,
-                };
-                return newArticles;
-            });
+            setFilteredArticles((oldState) => ({
+                ...oldState,
+                articles: filteredArticles,
+            }));
         }
     };
 
@@ -95,19 +65,18 @@ const ArchivePage = (props) => {
                         onSubmitInput={handleSubmitInput}
                         onSubmitTag={handleSubmitTag}
                     />
-                    {/* <ListWithTabs /> */}
-                    {articles.filteredArticles.length === 0 &&
-                        articles.searchWord !== null && (
+                    {filteredArticles.articles.length === 0 &&
+                        filteredArticles.keyword !== null && (
                             <h3>
-                                '{articles.searchWord}'와(과) 일치하는
+                                '{filteredArticles.keyword}'와(과) 일치하는
                                 검색결과가 없습니다. 아래의 게시물들은
                                 어떠신가요?
                             </h3>
                         )}
-                    {articles.filteredArticles.length !== 0 ? (
-                        <ListWithTabs cardData={articles.filteredArticles} />
+                    {filteredArticles.articles.length !== 0 ? (
+                        <ListWithTabs cardData={filteredArticles.articles} />
                     ) : (
-                        <ListWithTabs cardData={articles.articles} />
+                        <ListWithTabs cardData={articles} />
                     )}
                 </>
             }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,39 +1,45 @@
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+import { articleSelector } from '../atom/articleAtom';
 import BannerCarousel, { itemsForHomePage } from '../components/BannerCarousel';
 import ProductCardList from '../components/ProductCardList';
 import SearchForm from '../components/search/SearchForm';
 import PageTemplate from '../template/PageTemplate';
 
-const HomePage = (props) => (
-    <PageTemplate
-        contents={
-            <StyledHomePage>
-                <SearchForm />
-                <div className="ScollList-container">
-                    <h1 className={'title'}>지금 가장 조회수가 높은 👀</h1>
-                    <ScrollList>
-                        <ProductCardList />
-                    </ScrollList>
-                </div>
-                <div className="ScollList-container">
-                    <h1 className={'title'}>가장 많이 사용된 스택 C#</h1>
-                    <ScrollList>
-                        <ProductCardList />
-                    </ScrollList>
-                </div>
-                <div className="ScollList-container">
-                    <h1 className={'title'}>지금 막 올라왔어요 🆕</h1>
-                    <ScrollList>
-                        <ProductCardList />
-                    </ScrollList>
-                </div>
-            </StyledHomePage>
-        }
-    >
-        <BannerCarousel items={itemsForHomePage} />
-    </PageTemplate>
-);
+const HomePage = (props) => {
+    const articles = useRecoilValue(articleSelector);
+
+    return (
+        <PageTemplate
+            contents={
+                <StyledHomePage>
+                    <SearchForm />
+                    <div className="ScollList-container">
+                        <h1 className={'title'}>지금 가장 조회수가 높은 👀</h1>
+                        <ScrollList>
+                            <ProductCardList cardData={articles} />
+                        </ScrollList>
+                    </div>
+                    <div className="ScollList-container">
+                        <h1 className={'title'}>가장 많이 사용된 스택 C#</h1>
+                        <ScrollList>
+                            <ProductCardList cardData={articles} />
+                        </ScrollList>
+                    </div>
+                    <div className="ScollList-container">
+                        <h1 className={'title'}>지금 막 올라왔어요 🆕</h1>
+                        <ScrollList>
+                            <ProductCardList cardData={articles} />
+                        </ScrollList>
+                    </div>
+                </StyledHomePage>
+            }
+        >
+            <BannerCarousel items={itemsForHomePage} />
+        </PageTemplate>
+    );
+};
 
 const StyledHomePage = styled.div`
     .title {


### PR DESCRIPTION
## 작업내용
**수정: TagSearch, TitleSearch 버그 수정**
- TagSearch와 TitleSearch에서 공통으로 사용하는 form 스타일링을 분리하기 위해 StyledForm을 만들었는데, 해당 컴포넌트에서 이벤트 리스너가 등록되지 않고 있었습니다.
- 전체 props에서 object delete 연산을 사용해 children을 제외한 부분을 컴포넌트에 그대로 전달하는 방식으로 수정했습니다.

**추가: articles state를 recoil state로 변환**
- npm i로 recoil, @types/uuid 라이브러리를 설치를 진행 해주세요.
- API 호출이 필요한 articles 데이터는 최초 1회만 가져옵니다.
- Expectation Violation: Duplicate atom key 에러 메시지를 해결하기 위해 Atom의 key값에 난수를 추가했습니다.


## 노션기록
https://ethereal-flannel-f4e.notion.site/c91d17609ec74700b81710b0bbc89af1

## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?