### PR TITLE
추가: 작품 상세페이지 스타일 수정 및 작품 목록으로 돌아가기 버튼 추가

### DIFF
--- a/src/components/ProjectInfoBox.jsx
+++ b/src/components/ProjectInfoBox.jsx
@@ -33,12 +33,16 @@ const ProjectInfoBox = ({ article }) => {
         </ul>
       </Box>
       <Box>
-        <Button className="button" variant="outlined" sx={{ mr: 1 }}>
+        <Button className="button" variant="outlined" disabled sx={{ mr: 1 }}>
           작가에게 연락하기
         </Button>
-        <Button className="button" variant="contained" sx={{ boxShadow: 0 }}>
+        <ColoredButton
+          className="button"
+          variant="contained"
+          sx={{ boxShadow: 0 }}
+        >
           수정하기
-        </Button>
+        </ColoredButton>
       </Box>
     </InfoContainer>
   );
@@ -49,6 +53,7 @@ const InfoContainer = styled.div`
   padding-top: 1rem;
   padding-bottom: 1rem;
 
+  color: ${({ theme }) => theme.colors.text};
   display: flex;
   justify-content: space-between;
 
@@ -62,7 +67,7 @@ const InfoContainer = styled.div`
     align-items: center;
     margin-bottom: 1rem;
     font-size: 1.6rem;
-    color: #555;
+    color: ${({ theme }) => theme.colors.darkgray};
   }
   .info-tags {
     display: flex;
@@ -75,6 +80,10 @@ const InfoContainer = styled.div`
   .button {
     font-size: 1.4rem;
   }
+`;
+
+const ColoredButton = styled(Button)`
+  background-color: ${({ theme }) => theme.colors.primary};
 `;
 
 export default ProjectInfoBox;

--- a/src/components/ProjectInfoBox.jsx
+++ b/src/components/ProjectInfoBox.jsx
@@ -45,6 +45,7 @@ const ProjectInfoBox = ({ article }) => {
 };
 
 const InfoContainer = styled.div`
+  margin-top: 2rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
 

--- a/src/pages/ProjectDetailPage.jsx
+++ b/src/pages/ProjectDetailPage.jsx
@@ -37,12 +37,7 @@ const ProjectDetailPage = (props) => {
   };
 
   return (
-    <PageTemplate contents={<MainContents article={article} />}>
-      <ThumbnailImage
-        src="https://via.placeholder.com/700x400"
-        alt="post-thumbnail"
-      />
-    </PageTemplate>
+    <PageTemplate contents={<MainContents article={article} />}></PageTemplate>
   );
 };
 
@@ -93,6 +88,10 @@ const MainContents = ({ article }) => {
 
   return (
     <>
+      <ThumbnailImage
+        src="https://via.placeholder.com/690x400"
+        alt="post-thumbnail"
+      />
       <ProjectInfoBox article={article} />
       <Paper elevation={5} sx={{ mt: 3, mb: 8, p: 5, borderRadius: 8 }}>
         <TextViewer data={initialContent} />

--- a/src/pages/ProjectDetailPage.jsx
+++ b/src/pages/ProjectDetailPage.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, Navigate, useParams } from "react-router-dom";
 import { getArticles } from "../api/article";
 import ProjectInfoBox from "../components/ProjectInfoBox";
 import TextViewer from "../components/TextViewer";
 import PageTemplate from "../template/PageTemplate";
-import { Paper } from "@mui/material";
+import { Button, Paper } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import styled from "styled-components";
 
 const ProjectDetailPage = (props) => {
@@ -88,6 +89,11 @@ const MainContents = ({ article }) => {
 
   return (
     <>
+      <Link to="/archive">
+        <BackButton variant="text" startIcon={<ArrowBackIcon />}>
+          목록으로 돌아가기
+        </BackButton>
+      </Link>
       <ThumbnailImage
         src="https://via.placeholder.com/690x400"
         alt="post-thumbnail"
@@ -107,6 +113,19 @@ const ThumbnailImage = styled.img`
   height: auto;
   object-fit: contain;
   display: block;
+`;
+
+const BackButton = styled(Button)`
+  /* display: flex; */
+  /* align-items: center; */
+  margin-bottom: 1rem;
+  transition: all 0.5s;
+  font-size: 1.4rem;
+  color: ${({ theme }) => theme.colors.darkgray};
+
+  &:hover {
+    transform: scale(1.05);
+  }
 `;
 
 export default ProjectDetailPage;

--- a/src/styles/style.js
+++ b/src/styles/style.js
@@ -47,18 +47,6 @@ const deviceSizes = {
   tabletL: "1024px",
 };
 
-const colors = {
-  primary: "#2f51cf",
-  secondary: "#9aaae6",
-  error: "#eb5757",
-  black: "#000000",
-  darkgray: "#767676",
-  middlegray: "#c4c4c4",
-  lightgray: "#dbdbdb",
-  whitegray: "#f2f2f2",
-  white: "#FFFFFF",
-};
-
 const device = {
   mobileS: `only screen and (max-width: ${deviceSizes.mobileS})`,
   mobileM: `only screen and (max-width: ${deviceSizes.mobileM})`,
@@ -69,7 +57,6 @@ const device = {
 
 const style = {
   fontSizes,
-  colors,
   deviceSizes,
   device,
   paddings,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,22 +1,31 @@
 const theme = {
-    light: {
-        id: 'T_001',
-        name: 'Light',
-        colors: {
-            body: '#fff',
-            text: '#000',
-            background: 'rgb(249,249,249)',
-            button: {
-                text: '#FFFFFF',
-                background: '#000000',
-            },
-            link: {
-                text: 'teal',
-                opacity: 1,
-            },
-        },
-        font: 'SpoqaHanSansNeo, system-ui, -apple-system, BlinkMacSystemFont, Roboto, sans-serif;',
+  light: {
+    id: "T_001",
+    name: "Light",
+    colors: {
+      body: "#fff",
+      text: "#222",
+      background: "rgb(249,249,249)",
+      button: {
+        text: "#FFFFFF",
+        background: "#000000",
+      },
+      link: {
+        text: "teal",
+        opacity: 1,
+      },
+      primary: "#3579F6",
+      secondary: "#9aaae6",
+      error: "#eb5757",
+      black: "#000",
+      darkgray: "#767676",
+      middlegray: "#c4c4c4",
+      lightgray: "#dbdbdb",
+      whitegray: "#f2f2f2",
+      white: "#fff",
     },
+    font: "SpoqaHanSansNeo, system-ui, -apple-system, BlinkMacSystemFont, Roboto, sans-serif;",
+  },
 };
 
 /**


### PR DESCRIPTION
## 작업내용
- 기존에 브라우저의 가로 너비를 크게 했을 때, 상세페이지 썸네일이 화면을 가득 채우는 문제를 해결했습니다.
- "작가에게 연락하기" 서비스가 개발되지 않아 버튼을 disabled 처리하였습니다.
- 컬러지정 편의성을 위해 style.js의 colors 객체를 theme.js의 colors와 병합하였습니다.
- "목록으로 돌아가기" 버튼 추가

## 상세페이지에서 추후 개발해야 하는 부분
- [ ] article 데이터 state 가져오기

시간이 될 때 이전 작품/다음 작품 버튼도 만들면 편리할 것 같습니다.

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?