### PR TITLE
추가: EditPage 등록모드/수정모드 식별

### DIFF
--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -16,7 +16,7 @@ const textSize = {
   title: style.fontSizes.xxl,
 };
 
-const EditForm = (props) => {
+const EditForm = ({ editMode, initialArticle }) => {
   // 프로젝트 제목 및 소개 최소길이
   const TITLE_MIN_LENGTH = 1;
   const INTRO_MIN_LENGTH = 20;
@@ -119,6 +119,7 @@ const EditForm = (props) => {
               style: { fontSize: textSize.title },
               maxLength: 40,
             }}
+            defaultValue={initialArticle && initialArticle.title}
             onInput={handleTitleInput}
           />
         </Box>
@@ -133,6 +134,7 @@ const EditForm = (props) => {
           </Typography>
           <TextEditor
             ref={editorRef} // DOM 선택용 useRef
+            initialContent={initialArticle && initialArticle.content}
           ></TextEditor>
         </Box>
         <Box
@@ -148,7 +150,7 @@ const EditForm = (props) => {
             variant="text"
             sx={{ mr: 1, fontSize: textSize.base }}
           >
-            임시저장
+            취소
           </Button>
           <Button
             variant="contained"

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -16,7 +16,7 @@ const textSize = {
   title: style.fontSizes.xxl,
 };
 
-const UploadForm = (props) => {
+const EditForm = (props) => {
   // 프로젝트 제목 및 소개 최소길이
   const TITLE_MIN_LENGTH = 1;
   const INTRO_MIN_LENGTH = 20;
@@ -163,4 +163,4 @@ const UploadForm = (props) => {
   );
 };
 
-export default UploadForm;
+export default EditForm;

--- a/src/components/TextEditor.jsx
+++ b/src/components/TextEditor.jsx
@@ -9,74 +9,30 @@ import "prismjs/themes/prism.css";
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css";
 import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight";
 
-// 에디터 글양식
-const initialContent = [
-  "## 팀 소개 및 역할 분담",
-  "",
-  "프로젝트에 참여한 사람의 **학번**, **이름**과 함께 각각 어떤 역할을 맡았는지 작성해 주세요.",
-  "",
-  "예 )",
-  "",
-  "- 20220000 김** - 기획 및 UI/UX 디자인",
-  "- 20210000 박** - 개발 일정 관리 및 퍼블리싱, 상품 업로드 및 좋아요 기능 프론트엔드 구현",
-  "- 20200000 이** - 팀 워크스페이스 관리 및 DB 설계, 백엔드 개발",
-  "",
-  "## 개요",
-  "",
-  "어떤 프로젝트를 진행했는지 간략하게 소개해 주세요.",
-  "",
-  "## 기술 스택",
-  "",
-  "프로젝트에 사용한 기술들을 소개해 주세요.",
-  "",
-  "예 ) 언어, 라이브러리, 프레임워크, 디자인 툴, 협업 툴 등",
-  "",
-  "- 언어 : C#, Java, 스크래치, 앱인벤터 ...",
-  "- 라이브러리 : React, JQuery ...",
-  "- 협업 툴 : Notion, 카카오톡, Slack ...",
-  "",
-  "## 주요 기능 소개",
-  "",
-  "프로젝트의 주된 기능들을 소개해 주세요.",
-  "",
-  "**실제로 구동되는 이미지를 최소 2개 이상** 첨부해 주세요.",
-  "",
-  "## 문제해결 경험 및 느낀 점",
-  "",
-  "프로젝트를 진행하며 어떤 기술적 문제나 협업에서의 어려움 등을 겪었고 그것을 풀어내기 위해 어떤 시도를 해보았는지,",
-  ,
-  "그리고 어떤 점들을 배웠는지 등에 대해 작성해주세요.",
-  "",
-  "## 프로젝트 코드",
-  "",
-  "[깃허브](https://github.com/)에 프로젝트 전체 코드를 올려 repository url을 제출해주세요.",
-  "앱인벤터, 스크래치 프로젝트의 경우 해당 프로젝트의 url을 제출하시면 됩니다.",
-].join("\n");
-
-// 에디터 설정
-const settings = {
-  previewStyle: "tab", // 미리보기 스타일
-  height: "500px", // 에디터 창 높이
-  initialEditType: "wysiwyg",
-  language: "ko",
-  useCommandShortcut: false, // 키보드 입력 컨트롤 방지
-  toolbarItems: [
-    // 툴바 옵션
-    ["bold", "italic", "strike"],
-    ["quote", "code", "codeblock"],
-    ["ul", "ol"],
-    ["table", "image", "link"],
-  ],
-  plugins: [codeSyntaxHighlight],
-  initialValue: initialContent,
-};
-
 const onUploadImage = async (blob, callback) => {
   const res = await uploadImage(blob);
   callback(res.url, "alt text");
 };
 
-const TextEditor = ({ editorRef }) => {
+const TextEditor = ({ editorRef, initialContent }) => {
+  // 에디터 설정
+  const settings = {
+    previewStyle: "tab", // 미리보기 스타일
+    height: "500px", // 에디터 창 높이
+    initialEditType: "wysiwyg",
+    language: "ko",
+    useCommandShortcut: false, // 키보드 입력 컨트롤 방지
+    toolbarItems: [
+      // 툴바 옵션
+      ["bold", "italic", "strike"],
+      ["quote", "code", "codeblock"],
+      ["ul", "ol"],
+      ["table", "image", "link"],
+    ],
+    plugins: [codeSyntaxHighlight],
+    initialValue: initialContent,
+  };
+
   return (
     <Editor
       ref={editorRef} // DOM 선택용 useRef
@@ -87,6 +43,51 @@ const TextEditor = ({ editorRef }) => {
       {...settings}
     ></Editor>
   );
+};
+
+// initialContent를 Prop으로 받지 않으면 기본 글양식 적용
+TextEditor.defaultProps = {
+  initialContent: [
+    "## 팀 소개 및 역할 분담",
+    "",
+    "프로젝트에 참여한 사람의 **학번**, **이름**과 함께 각각 어떤 역할을 맡았는지 작성해 주세요.",
+    "",
+    "예 )",
+    "",
+    "- 20220000 김** - 기획 및 UI/UX 디자인",
+    "- 20210000 박** - 개발 일정 관리 및 퍼블리싱, 상품 업로드 및 좋아요 기능 프론트엔드 구현",
+    "- 20200000 이** - 팀 워크스페이스 관리 및 DB 설계, 백엔드 개발",
+    "",
+    "## 개요",
+    "",
+    "어떤 프로젝트를 진행했는지 간략하게 소개해 주세요.",
+    "",
+    "## 기술 스택",
+    "",
+    "프로젝트에 사용한 기술들을 소개해 주세요.",
+    "",
+    "예 ) 언어, 라이브러리, 프레임워크, 디자인 툴, 협업 툴 등",
+    "",
+    "- 언어 : C#, Java, 스크래치, 앱인벤터 ...",
+    "- 라이브러리 : React, JQuery ...",
+    "- 협업 툴 : Notion, 카카오톡, Slack ...",
+    "",
+    "## 주요 기능 소개",
+    "",
+    "프로젝트의 주된 기능들을 소개해 주세요.",
+    "",
+    "**실제로 구동되는 이미지를 최소 2개 이상** 첨부해 주세요.",
+    "",
+    "## 문제해결 경험 및 느낀 점",
+    "",
+    "프로젝트를 진행하며 어떤 기술적 문제나 협업에서의 어려움 등을 겪었고 그것을 풀어내기 위해 어떤 시도를 해보았는지,",
+    "그리고 어떤 점들을 배웠는지 등에 대해 작성해주세요.",
+    "",
+    "## 프로젝트 코드",
+    "",
+    "[깃허브](https://github.com/)에 프로젝트 전체 코드를 올려 repository url을 제출해주세요.",
+    "앱인벤터, 스크래치 프로젝트의 경우 해당 프로젝트의 url을 제출하시면 됩니다.",
+  ].join("\n"),
 };
 
 export default TextEditor;

--- a/src/pages/EditPage.jsx
+++ b/src/pages/EditPage.jsx
@@ -24,9 +24,6 @@ const EditPage = () => {
 
   return (
     <PageTemplate>
-      EditPage
-      <div>id: {id}</div>
-      <div>editMode: {editMode}</div>
       {editMode === "post" ? (
         <EditForm editMode={editMode} />
       ) : (

--- a/src/pages/EditPage.jsx
+++ b/src/pages/EditPage.jsx
@@ -1,6 +1,39 @@
-import React from 'react';
-import PageTemplate from '../template/PageTemplate';
+import React, { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { getArticle } from "../api/article";
+import EditForm from "../components/EditForm";
 
-const EditPage = () => <PageTemplate>EditPage</PageTemplate>;
+import PageTemplate from "../template/PageTemplate";
+
+const EditPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const id = searchParams.get("id");
+  const editMode = id ? "patch" : "post";
+
+  const [article, setArticle] = useState();
+
+  useEffect(() => {
+    if (id !== null) {
+      (async function _getArticles() {
+        const response = await getArticle(id.toString());
+        const result = response.data.article;
+        setArticle(result);
+      })();
+    }
+  }, [id]);
+
+  return (
+    <PageTemplate>
+      EditPage
+      <div>id: {id}</div>
+      <div>editMode: {editMode}</div>
+      {editMode === "post" ? (
+        <EditForm editMode={editMode} />
+      ) : (
+        article && <EditForm editMode={editMode} initialArticle={article} />
+      )}
+    </PageTemplate>
+  );
+};
 
 export default EditPage;


### PR DESCRIPTION
## 작업내용
Issue: #36 작업을 완료했습니다.
쿼리스트링을 활용해,
- 등록 모드일 때는 쿼리스트링 없이, “/edit”
- 수정 모드일 때는 쿼리스트링 id를 활용해 “/edit?id={id}”
으로 EditPage에 접근하면 어떤 모드인지 식별이 가능합니다.

- EditPage에서 쿼리스트링을 가져와 모드 식별
- 수정모드에서 EditForm, TUI Editor가 기존 article 정보를 default 값으로 갖도록 코드 수정

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?