### PR TITLE
추가: 작품편집 페이지 등록/수정 요청 관련 함수 작성

### DIFF
--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -137,7 +137,7 @@ const EditForm = ({ editMode, initialArticle }) => {
   };
 
   // editMode에 따라 API request 요청
-  const sendAPIRequestByEditMode = async (editMode, data, id) => {
+  const updateArticle = async (editMode, data, id) => {
     const response =
       editMode === "post"
         ? await postArticle(data)
@@ -169,7 +169,7 @@ const EditForm = ({ editMode, initialArticle }) => {
     ) {
       const data = createStateMap();
       // DB에 업로드
-      // const articleId = sendAPIRequestByEditMode(
+      // const articleId = updateArticle(
       //   editMode,
       //   data,
       //   initialArticle && initialArticle.id

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -172,13 +172,13 @@ const EditForm = ({ editMode, initialArticle }) => {
     ) {
       const data = createStateMap();
       // DB에 업로드
-      const articleId = sendAPIRequestByEditMode(
-        editMode,
-        data,
-        initialArticle && initialArticle.id
-      );
+      // const articleId = sendAPIRequestByEditMode(
+      //   editMode,
+      //   data,
+      //   initialArticle && initialArticle.id
+      // );
       window.alert("저장되었습니다.");
-      navigate(`/proejct/${articleId}`);
+      // navigate(`/proejct/${articleId}`);
     } else {
       console.log("업로드할 수 없습니다");
       console.log(

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -1,11 +1,16 @@
 import React, { useRef, useState, useEffect } from "react";
-import { Button, Paper, TextField } from "@mui/material";
+import styled from "styled-components";
+import { useNavigate, Link } from "react-router-dom";
+
 import TextEditor from "./TextEditor.jsx";
 import TagInput from "./TagInput.jsx";
-import styled from "styled-components";
+import { Button, Paper, TextField } from "@mui/material";
 
-// 이미지 업로드 api
+// 이미지 업로드 API
 import uploadImage from "../api/uploadImage.js";
+
+// article API
+import { patchArticle, postArticle } from "../api/article.js";
 
 // 유효성검사 함수 import
 import {
@@ -15,11 +20,6 @@ import {
   checkTagListValid,
   checkThumbnailValid,
 } from "./EditFormValidator";
-import uploadImage from "../api/uploadImage.js";
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { patchArticle, postArticle } from "../api/article.js";
-import { Link } from "react-router-dom";
 
 // component
 const InputField = ({ title, desc, children }) => (

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -15,6 +15,7 @@ import {
 import uploadImage from "../api/uploadImage.js";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { patchArticle, postArticle } from "../api/article.js";
 
 // component
 const InputField = ({ title, desc, children }) => (
@@ -120,6 +121,33 @@ const EditForm = ({ editMode, initialArticle }) => {
     }
   }, []);
 
+  // state들로 구성된 객체 반환
+  const createStateMap = () => {
+    return {
+      title: title,
+      description: description,
+      content: editorRef.current?.getInstance().getMarkdown(),
+      hashtagList: tagList.map((tag) => tag.label),
+      thumbnail: thumbnailURL,
+    };
+  };
+
+  // editMode에 따라 API request 요청
+  const sendAPIRequestByEditMode = (editMode, data, id) => {
+    async function _postArticle() {
+      const response = await postArticle(data);
+      return response.data.articleId;
+    }
+    async function _patchArticle() {
+      const response = await patchArticle(id, data);
+      return response.data.articleId;
+    }
+
+    const articleId = editMode === "post" ? _postArticle() : _patchArticle();
+
+    return articleId;
+  };
+
   // 등록 버튼 핸들러
   /**
    * @Todo Article 데이터구조 수정되면 주석 해제
@@ -142,10 +170,17 @@ const EditForm = ({ editMode, initialArticle }) => {
       isTagListValid &&
       isThumbnailValid
     ) {
+      const data = createStateMap();
       // DB에 업로드
+      const articleId = sendAPIRequestByEditMode(
+        editMode,
+        data,
+        initialArticle && initialArticle.id
+      );
       window.alert("저장되었습니다.");
-      // navigate(`/proejct/${articleId}`);
+      navigate(`/proejct/${articleId}`);
     } else {
+      console.log("업로드할 수 없습니다");
       console.log(
         isTitleValid,
         isDescriptionValid,
@@ -153,8 +188,8 @@ const EditForm = ({ editMode, initialArticle }) => {
         isTagListValid,
         isThumbnailValid
       );
-      return;
     }
+    return;
   };
 
   // 프로젝트 제목 input 핸들러

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -133,19 +133,12 @@ const EditForm = ({ editMode, initialArticle }) => {
   };
 
   // editMode에 따라 API request 요청
-  const sendAPIRequestByEditMode = (editMode, data, id) => {
-    async function _postArticle() {
-      const response = await postArticle(data);
-      return response.data.articleId;
-    }
-    async function _patchArticle() {
-      const response = await patchArticle(id, data);
-      return response.data.articleId;
-    }
-
-    const articleId = editMode === "post" ? _postArticle() : _patchArticle();
-
-    return articleId;
+  const sendAPIRequestByEditMode = async (editMode, data, id) => {
+    const response =
+      editMode === "post"
+        ? await postArticle(data)
+        : await patchArticle(id, data);
+    return response.data.articleId;
   };
 
   // 등록 버튼 핸들러

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -14,6 +14,7 @@ import {
 } from "./EditFormValidator";
 import uploadImage from "../api/uploadImage.js";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 // component
 const InputField = ({ title, desc, children }) => (
@@ -83,6 +84,8 @@ const EditForm = ({ editMode, initialArticle }) => {
   // Editor DOM 선택용
   const editorRef = useRef();
 
+  const navigate = useNavigate();
+
   // states
   const [title, setTitle] = useState("");
   const [titleError, setTitleError] = useState({
@@ -98,14 +101,16 @@ const EditForm = ({ editMode, initialArticle }) => {
   const [tagList, setTagList] = useState([{ key: 0, label: "컴공 전시회" }]);
 
   // 수정모드에서 기존값으로 state set
+  /**
+   * @Todo Article 데이터구조 수정되면 주석 해제
+   */
   const setInitialContent = () => {
-    console.log(initialArticle);
     const initialTagList = initialArticle.hashtagList.map((tagName, index) => {
       return { key: index, label: tagName };
     });
     setTitle(initialArticle.title);
-    setDescription(initialArticle.title);
-    setThumbnailURL();
+    // setDescription(initialArticle.description);
+    // setThumbnailURL(initialArticle.thumbnail);
     setTagList(initialTagList);
   };
 
@@ -116,6 +121,9 @@ const EditForm = ({ editMode, initialArticle }) => {
   }, []);
 
   // 등록 버튼 핸들러
+  /**
+   * @Todo Article 데이터구조 수정되면 주석 해제
+   */
   const handleSubmit = () => {
     const isTitleValid = checkTitleValid(title, titleError, setTitleError);
     const isDescriptionValid = checkDescriptionValid(
@@ -136,7 +144,7 @@ const EditForm = ({ editMode, initialArticle }) => {
     ) {
       // DB에 업로드
       window.alert("저장되었습니다.");
-      // 작품 상세페이지로 navigate
+      // navigate(`/proejct/${articleId}`);
     } else {
       console.log(
         isTitleValid,


### PR DESCRIPTION
## 작업내용
작품편집 페이지에서 등록/수정 요청에 관한 함수를 작업했습니다.
아직 Article 데이터구조와 API가 수정되지 않아 sendAPIRequestByEditMode 함수를 호출하는 부분은 주석처리해두었습니다.

### createStateMap()
- 제목, 한줄설명, 내용, 해시태그, 썸네일 URL state들로 구성된 객체를 반환
- Submit 후 유효성 검사 통과 시 createStateMap을 통해 요청 body에 담을 data 객체 획득
```jsx
// state들로 구성된 객체를 반환
  const createStateMap = () => {
    return {
      title: title,
      description: description,
      content: editorRef.current?.getInstance().getMarkdown(),
      hashtagList: tagList.map((tag) => tag.label),
      thumbnail: thumbnailURL,
    };
  };
```

### ~~sendAPIRequestByEditMode(editMode, data, id)~~ updateArticle(editMode, data, id)
- editMode에 따라 patch 혹은 post 요청을 보냄
- 등록 / 수정한 게시글의 Id를 반환
```jsx
  // editMode에 따라 API request 요청
  const updateArticle = async (editMode, data, id) => {
    const response =
      editMode === "post"
        ? await postArticle(data)
        : await patchArticle(id, data);
    return response.data.articleId;
  };
```

## 중점적으로 봐주었으면 하는 부분
~~함수 이름이 너무 길어서 마음이 아픕니다~~
해결~


## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?