### PR TITLE
수정: 게시글 업로드 기능 주석 해제 및 상세페이지 사용자 확인

### DIFF
--- a/src/api/article.js
+++ b/src/api/article.js
@@ -128,7 +128,7 @@ export const patchArticle = (
   articleId,
   { title, description, content, hashtagList, thumbnail } = {}
 ) => {
-  articleId && checkType(articleId, "string");
+  // articleId && checkType(articleId, "string");
   title && checkType(title, "string");
   description && checkType(description, "string");
   content && checkType(content, "string");

--- a/src/atom/userAtom.js
+++ b/src/atom/userAtom.js
@@ -1,17 +1,17 @@
-import { atom, selector } from 'recoil';
-import { v1 } from 'uuid';
+import { atom, selector } from "recoil";
+import { v1 } from "uuid";
 
 const userAtom = atom({
   key: `userAtom/${v1()}`,
   default: {
     isLogin: false,
-    userId: 'hoit',
-    username: '호잇',
-    email: 'hoit@gmail.com',
+    userId: "hoit",
+    username: "호잇",
+    email: "hoit@gmail.com",
     profileImageUrl:
-      'https://i.picsum.photos/id/237/200/300.jpg?hmac=TmmQSbShHz9CdQm0NkEjx1Dyh_Y984R9LpNrpvH2D_U',
-    providerType: '',
-    roleType: '',
+      "https://i.picsum.photos/id/237/200/300.jpg?hmac=TmmQSbShHz9CdQm0NkEjx1Dyh_Y984R9LpNrpvH2D_U",
+    providerType: "",
+    roleType: "",
   },
 });
 
@@ -23,13 +23,13 @@ const userSelector = selector({
   set: ({ set }, { isLogin }) => {
     // 추후 api.getUser(token)의 response로 변경될 예정입니다.
     const tmpUserInfo = {
-      userId: 'hoit',
-      username: '호잇',
-      email: 'hoit@gmail.com',
+      userId: "141",
+      username: "호잇",
+      email: "hoit@gmail.com",
       profileImageUrl:
-        'https://i.picsum.photos/id/237/200/300.jpg?hmac=TmmQSbShHz9CdQm0NkEjx1Dyh_Y984R9LpNrpvH2D_U',
-      providerType: '',
-      roleType: '',
+        "https://i.picsum.photos/id/237/200/300.jpg?hmac=TmmQSbShHz9CdQm0NkEjx1Dyh_Y984R9LpNrpvH2D_U",
+      providerType: "",
+      roleType: "",
     };
     set(userAtom, { isLogin, ...tmpUserInfo });
   },

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -20,6 +20,7 @@ import {
   checkTagListValid,
   checkThumbnailValid,
 } from "./EditFormValidator";
+import { useCallback } from "react";
 
 // component
 const InputField = ({ title, desc, children }) => (
@@ -105,24 +106,21 @@ const EditForm = ({ editMode, initialArticle }) => {
   const [tagList, setTagList] = useState([{ key: 0, label: "컴공 전시회" }]);
 
   // 수정모드에서 기존값으로 state set
-  /**
-   * @Todo Article 데이터구조 수정되면 주석 해제
-   */
-  const setInitialContent = () => {
+  const setInitialContent = useCallback(() => {
     const initialTagList = initialArticle.hashtagList.map((tagName, index) => {
       return { key: index, label: tagName };
     });
     setTitle(initialArticle.title);
-    // setDescription(initialArticle.description);
-    // setThumbnailURL(initialArticle.thumbnail);
+    setDescription(initialArticle.description);
+    setThumbnailURL(initialArticle.thumbnail);
     setTagList(initialTagList);
-  };
+  }, [setTitle, setDescription, setThumbnailURL, setTagList]);
 
   useEffect(() => {
     if (editMode === "patch") {
       setInitialContent();
     }
-  }, []);
+  }, [setInitialContent]);
 
   // state들로 구성된 객체 반환
   const createStateMap = () => {
@@ -168,13 +166,13 @@ const EditForm = ({ editMode, initialArticle }) => {
     ) {
       const data = createStateMap();
       // DB에 업로드
-      // const articleId = updateArticle(
-      //   editMode,
-      //   data,
-      //   initialArticle && initialArticle.id
-      // );
+      const articleId = updateArticle(
+        editMode,
+        data,
+        initialArticle && initialArticle.id
+      );
       window.alert("저장되었습니다.");
-      // navigate(`/proejct/${articleId}`);
+      navigate(`/proejct/${articleId}`);
     } else {
       console.log("업로드할 수 없습니다");
       console.log(

--- a/src/components/ProjectInfoBox.jsx
+++ b/src/components/ProjectInfoBox.jsx
@@ -16,7 +16,7 @@ const ProjectInfoBox = ({ articleId }) => {
   const article = useRecoilValue(selectedArticleSelector(articleId));
   const navigate = useNavigate();
 
-  const isAuthor = user.id === article.user.id;
+  const isAuthor = user.userId === article.user.id + "";
 
   const date = {
     year: article && article.createdAt[0],


### PR DESCRIPTION
## 작업내용
- 현재 user Atom에서 기본 return으로 id를 받아오고 있어 작성자 본인 확인이 어려움
- 임시로 userAtom에서 제공하는 id를 141로 변경
- 

## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [ ]  의미 있는 커밋 메시지를 작성하셨나요?