### PR TITLE
수정: 썸네일 이미지 반영 및 UI 디테일 수정

### DIFF
--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -245,7 +245,7 @@ const EditForm = ({ editMode, initialArticle }) => {
             required
             error={descriptionError.error}
             helperText={descriptionError.message}
-            defaultValue={initialArticle && initialArticle.title}
+            defaultValue={initialArticle && initialArticle.description}
             inputProps={{
               style: {
                 fontSize: 16,

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -5,9 +5,9 @@ import CardMedia from "@mui/material/CardMedia";
 import Typography from "@mui/material/Typography";
 import TagArray from "./TagArray";
 
-const ProductCard = ({ thumbnailUrl, alt, title, description, tags }) => (
+const ProductCard = ({ thumbnailUrl, title, description, tags }) => (
   <Card sx={{ maxWidth: 345, borderRadius: "15px" }}>
-    <CardMedia component="img" alt={alt} height="200" image={thumbnailUrl} />
+    <CardMedia component="img" alt={title} height="200" image={thumbnailUrl} />
     <CardContent>
       <Typography gutterBottom variant="h5" component="div">
         {title}
@@ -21,7 +21,7 @@ const ProductCard = ({ thumbnailUrl, alt, title, description, tags }) => (
 );
 
 ProductCard.defaultProps = {
-  thumbnailUrl: "https://via.placeholder.com/345x200",
+  thumbnail: "https://via.placeholder.com/345x200",
   alt: "비어있는 이미지",
   title: "프로젝트 제목",
   description: "설명",

--- a/src/components/ProductCardHoriz.jsx
+++ b/src/components/ProductCardHoriz.jsx
@@ -42,8 +42,7 @@ const StyledBox = styled(Box)`
 `;
 
 const ProductCardHoriz = ({
-  image,
-  alt,
+  thumbnailUrl,
   title,
   description,
   tags,
@@ -61,8 +60,8 @@ const ProductCardHoriz = ({
     <StyledCard sx={{ display: "flex", borderRadius: 5 }}>
       <CardMedia
         component="img"
-        image={image}
-        alt={alt}
+        image={thumbnailUrl}
+        alt={title}
         onClick={() => navigate(`/project/${articleId}`)}
       />
       <StyledCardContent>

--- a/src/components/ProductCardList.jsx
+++ b/src/components/ProductCardList.jsx
@@ -121,6 +121,9 @@ const ProductCardList = ({ cardData, horiz = false }) => {
       component="ul"
     >
       {cardData.map((data) => {
+        const tags = data.hashtagList.map((tag, i) => {
+          return { key: i, label: tag, href: "#" };
+        });
         return (
           <ListItem
             key={data.id}
@@ -138,21 +141,19 @@ const ProductCardList = ({ cardData, horiz = false }) => {
           >
             {horiz ? (
               <ProductCardHoriz
-                image={data.image}
-                alt={data.alt}
+                thumbnailUrl={data.thumbnail}
                 title={data.title}
                 description={data.description}
-                tags={data.tags}
+                tags={tags}
                 articleId={data.id}
                 createdAt={data.createdAt}
               />
             ) : (
               <ProductCard
-                image={data.image}
-                alt={data.alt}
+                thumbnailUrl={data.thumbnail}
                 title={data.title}
                 description={data.description}
-                tags={data.tags}
+                tags={tags}
               />
             )}
           </ListItem>

--- a/src/components/ProjectInfoBox.jsx
+++ b/src/components/ProjectInfoBox.jsx
@@ -45,9 +45,6 @@ const ProjectInfoBox = ({ articleId }) => {
         </ul>
       </Box>
       <Box className="container-button">
-        <Button className="button" variant="outlined" disabled sx={{ mr: 1 }}>
-          작가에게 연락하기
-        </Button>
         {isAuthor && (
           <ColoredButton
             className="button"

--- a/src/components/TagInput.jsx
+++ b/src/components/TagInput.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 const TagListItem = styled.li`
   margin-right: 10px;
+  margin-bottom: 10px;
 `;
 
 const TagListContainer = styled.ul`

--- a/src/pages/ProjectDetailPage.jsx
+++ b/src/pages/ProjectDetailPage.jsx
@@ -27,7 +27,7 @@ const MainContents = ({ article }) => {
     <>
       <BackButton />
       <ThumbnailImage
-        src={article.thumbnailUrl || `https://via.placeholder.com/690x400`}
+        src={article.thumbnail || `https://via.placeholder.com/690x400`}
         alt="post-thumbnail"
       />
       <ProjectInfoBox articleId={article.id} />


### PR DESCRIPTION
## 작업내용
- 데이터 구조 변경 전 지정되어있던 썸네일 placeholder 대신 실제 article의 썸네일이 들어가도록 수정했습니다.
- 카드뷰 해시태그를 실제 article의 태그가 들어가도록 수정했습니다.
- 작가에게 연락하기 버튼을 삭제했습니다.
- 태그 마진 등 디테일 스타일 작업

### 이후 작업
- 해시태그가 등록되지 않은 경우 카드 UI가 깨집니다
- 최소 1개 이상의 해시태그를 등록하도록 validation이 필요합니다
<img width="864" alt="image" src="https://user-images.githubusercontent.com/102221305/202914480-b773ccc9-73a6-4ded-b06c-2c47fc2302c3.png">
