### PR TITLE
article 관련 전역 상태 활용 구조 변경

### DIFF
--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -3,11 +3,9 @@ import { v1 } from "uuid";
 import { getAllArticles, getArticle } from "../api/article";
 import { cardDemoData } from "../components/card/ProductCardList";
 
-export const articleAtom = atom({
-  key: `articleAtom/${v1()}`,
-  default: {
-    articles: [],
-  },
+export const articlesState = atom({
+  key: `articlesState/${v1()}`,
+  default: [],
 });
 
 export const selectedArticleAtom = atom({
@@ -17,16 +15,25 @@ export const selectedArticleAtom = atom({
   },
 });
 
-export const filteredArticlesAtom = atom({
-  key: `filteredArticlesAtom/${v1()}`,
-  default: {
-    keyword: null,
-    articles: [],
+// 검색창에 input 바뀔 때 이 state를 변경함
+export const articlesFilterState = atom({
+  key: "articlesFilterState",
+  default: "",
+});
+
+// selector가 filter state를 이용해 필터링된 결과를 반환
+export const filteredArticlesSelector = selector({
+  key: `filteredArticlesSelector/${v1()}`,
+  get: ({ get }) => {
+    const filter = get(articlesFilterState);
+    const articles = get(articlesState);
+
+    return articles.filter(({ title }) => title.incluedes(filter));
   },
 });
 
-export const articleSelector = selector({
-  key: `articleSelector/${v1()}`,
+export const articlesSelector = selector({
+  key: `articlesSelector/${v1()}`,
   get: async ({ get }) => {
     const { data } = await getAllArticles();
     if (!data) {

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -18,13 +18,11 @@ export const articlesAtom = atom({
   ],
 });
 
-// 검색창에 input 바뀔 때 이 state를 변경함
 export const articlesFilterAtom = atom({
   key: `articlesFilterAtom/${v1()}`,
   default: "",
 });
 
-// selector가 filter state를 이용해 필터링된 결과를 반환
 export const filteredArticlesSelector = selector({
   key: `filteredArticlesSelector/${v1()}`,
   get: ({ get }) => {

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -36,9 +36,10 @@ export const filteredArticlesSelector = selector({
 export const curruntArticleSelector = selectorFamily({
   key: `curruntArticleSelector/${v1()}`,
   get: (id) => async () => {
-    if (id === undefined) return;
+    if (id === undefined) return {};
 
     const { data } = await getArticle(id);
+    if (!data) return {};
     return data.article;
   },
 });

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -36,7 +36,7 @@ export const filteredArticlesSelector = selector({
 export const curruntArticleSelector = selectorFamily({
   key: `curruntArticleSelector/${v1()}`,
   get: (id) => async () => {
-    if (id === undefined) return {};
+    if (id === null) return {};
 
     const { data } = await getArticle(id);
     if (!data) return {};

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -18,13 +18,6 @@ export const articlesState = atom({
   ],
 });
 
-export const selectedArticleAtom = atom({
-  key: `selectedArticleAtom/${v1()}`,
-  default: {
-    selectedArticle: {},
-  },
-});
-
 // 검색창에 input 바뀔 때 이 state를 변경함
 export const articlesFilterState = atom({
   key: `articlesFilterState/${v1()}`,

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -35,23 +35,12 @@ export const filteredArticlesSelector = selector({
   },
 });
 
-export const selectedArticleSelector = selectorFamily({
-  key: `selectedArticleSelector/${v1()}`,
-  get:
-    (articleId) =>
-    async ({ get }) => {
-      /**
-       * @TODO
-       * articlesAtom에 존재한다면 api를 호출하지 않습니다.
-       */
-      if (!articleId) {
-        return;
-      }
-      const { data } = await getArticle(articleId.toString());
-      if (!data) {
-        return {};
-      } else {
-        return data.article;
-      }
-    },
+export const curruntArticleSelector = selectorFamily({
+  key: `curruntArticleSelector/${v1()}`,
+  get: (id) => async () => {
+    if (id === undefined) return;
+
+    const { data } = await getArticle(id);
+    return data.article;
+  },
 });

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -17,7 +17,7 @@ export const selectedArticleAtom = atom({
 
 // 검색창에 input 바뀔 때 이 state를 변경함
 export const articlesFilterState = atom({
-  key: "articlesFilterState",
+  key: `articlesFilterState/${v1()}`,
   default: "",
 });
 
@@ -26,9 +26,9 @@ export const filteredArticlesSelector = selector({
   key: `filteredArticlesSelector/${v1()}`,
   get: ({ get }) => {
     const filter = get(articlesFilterState);
-    const articles = get(articlesState);
+    const articles = get(articlesSelector);
 
-    return articles.filter(({ title }) => title.incluedes(filter));
+    return articles.filter(({ title }) => title.includes(filter));
   },
 });
 

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -3,8 +3,8 @@ import { v1 } from "uuid";
 import { getAllArticles, getArticle } from "../api/article";
 import { cardDemoData } from "../components/card/ProductCardList";
 
-export const articlesState = atom({
-  key: `articlesState/${v1()}`,
+export const articlesAtom = atom({
+  key: `articlesAtom/${v1()}`,
   default: [],
   effects: [
     async ({ setSelf }) => {
@@ -19,8 +19,8 @@ export const articlesState = atom({
 });
 
 // 검색창에 input 바뀔 때 이 state를 변경함
-export const articlesFilterState = atom({
-  key: `articlesFilterState/${v1()}`,
+export const articlesFilterAtom = atom({
+  key: `articlesFilterAtom/${v1()}`,
   default: "",
 });
 
@@ -28,8 +28,8 @@ export const articlesFilterState = atom({
 export const filteredArticlesSelector = selector({
   key: `filteredArticlesSelector/${v1()}`,
   get: ({ get }) => {
-    const filter = get(articlesFilterState);
-    const articles = get(articlesState);
+    const filter = get(articlesFilterAtom);
+    const articles = get(articlesAtom);
 
     return articles.filter(({ title }) => title.includes(filter));
   },

--- a/src/atom/articleAtom.js
+++ b/src/atom/articleAtom.js
@@ -6,6 +6,16 @@ import { cardDemoData } from "../components/card/ProductCardList";
 export const articlesState = atom({
   key: `articlesState/${v1()}`,
   default: [],
+  effects: [
+    async ({ setSelf }) => {
+      const articles = await getAllArticles();
+      if (!articles) {
+        setSelf(cardDemoData);
+      } else {
+        setSelf(articles.data);
+      }
+    },
+  ],
 });
 
 export const selectedArticleAtom = atom({
@@ -26,21 +36,9 @@ export const filteredArticlesSelector = selector({
   key: `filteredArticlesSelector/${v1()}`,
   get: ({ get }) => {
     const filter = get(articlesFilterState);
-    const articles = get(articlesSelector);
+    const articles = get(articlesState);
 
     return articles.filter(({ title }) => title.includes(filter));
-  },
-});
-
-export const articlesSelector = selector({
-  key: `articlesSelector/${v1()}`,
-  get: async ({ get }) => {
-    const { data } = await getAllArticles();
-    if (!data) {
-      return [...cardDemoData];
-    } else {
-      return data;
-    }
   },
 });
 

--- a/src/components/ProjectInfoBox.jsx
+++ b/src/components/ProjectInfoBox.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { createSearchParams, useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { selectedArticleSelector } from "../atom/articleAtom";
+import { curruntArticleSelector } from "../atom/articleAtom";
 import { userSelector } from "../atom/userAtom";
 
 //components
@@ -12,9 +12,8 @@ import PersonIcon from "@mui/icons-material/Person";
 import { useEffect } from "react";
 import { StyledButton, StyledInfoContainer } from "./ProjectInfoBoxStyle";
 
-const ProjectInfoBox = ({ articleId }) => {
+const ProjectInfoBox = ({ article }) => {
   const user = useRecoilValue(userSelector);
-  const article = useRecoilValue(selectedArticleSelector(articleId));
   const navigate = useNavigate();
   const [isAuthor, setIsAuthor] = useState(false);
   useEffect(() => {

--- a/src/components/ProjectInfoBox.jsx
+++ b/src/components/ProjectInfoBox.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { createSearchParams, useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { curruntArticleSelector } from "../atom/articleAtom";
 import { userSelector } from "../atom/userAtom";
 
 //components

--- a/src/components/edit/EditForm.jsx
+++ b/src/components/edit/EditForm.jsx
@@ -140,8 +140,8 @@ const EditForm = ({ EDIT_MODE, initialArticle }) => {
     };
   };
 
-  // editMode에 따라 API request 요청
-  const updateArticle = async (editMode, data, id) => {
+  // EDIT_MODE에 따라 API request 요청
+  const updateArticle = async (EDIT_MODE, data, id) => {
     /**
      * Admin
      */
@@ -151,7 +151,7 @@ const EditForm = ({ EDIT_MODE, initialArticle }) => {
       data = { ...data, articleCategory: "질문" };
     }
     const response =
-      editMode === "post"
+        EDIT_MODE === "post"
         ? await postArticle(data)
         : await patchArticle(id, data);
     return response.data.articleId;

--- a/src/components/search/SearchForm.jsx
+++ b/src/components/search/SearchForm.jsx
@@ -1,26 +1,11 @@
 import React from "react";
-import { Navigate, useLocation } from "react-router-dom";
-import { useSetRecoilState } from "recoil";
-import { articlesFilterState } from "../../atom/articleAtom";
 import { SearchFormContainer } from "./SearchFormStyle";
 import TitleSearch from "./TitleSearch";
 
 const SearchForm = (props) => {
-  const setFilter = useSetRecoilState(articlesFilterState);
-  const location = useLocation();
-
-  const handleSubmitInput = (e) => {
-    const value = e.target.value;
-    setFilter(value.trim());
-
-    if (location === "/home") {
-      Navigate("/archive");
-    }
-  };
-
   return (
     <SearchFormContainer>
-      <TitleSearch onSubmitInput={handleSubmitInput} />
+      <TitleSearch />
       {/* <TagSearch tagList={tagList} onSubmitTag={onSubmitTag} /> */}
     </SearchFormContainer>
   );

--- a/src/components/search/SearchForm.jsx
+++ b/src/components/search/SearchForm.jsx
@@ -1,16 +1,26 @@
 import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import { articlesFilterState } from "../../atom/articleAtom";
 import { SearchFormContainer } from "./SearchFormStyle";
 import TitleSearch from "./TitleSearch";
 
-const SearchForm = ({
-  articles = [],
-  tagList = [],
-  onSubmitInput,
-  onSubmitTag,
-}) => {
+const SearchForm = (props) => {
+  const setFilter = useSetRecoilState(articlesFilterState);
+  const location = useLocation();
+
+  const handleSubmitInput = (e) => {
+    const value = e.target.value;
+    setFilter(value.trim());
+
+    if (location === "/home") {
+      Navigate("/archive");
+    }
+  };
+
   return (
     <SearchFormContainer>
-      <TitleSearch onSubmitInput={onSubmitInput} />
+      <TitleSearch onSubmitInput={handleSubmitInput} />
       {/* <TagSearch tagList={tagList} onSubmitTag={onSubmitTag} /> */}
     </SearchFormContainer>
   );

--- a/src/components/search/TitleSearch.jsx
+++ b/src/components/search/TitleSearch.jsx
@@ -4,11 +4,11 @@ import styled from "styled-components";
 import StyledForm from "./StyledForm";
 import { useSetRecoilState } from "recoil";
 import { useLocation, useNavigate } from "react-router-dom";
-import { articlesFilterState } from "../../atom/articleAtom";
+import { articlesFilterAtom } from "../../atom/articleAtom";
 
 const TitleSearch = (props) => {
   const [input, setInput] = useState();
-  const setFilter = useSetRecoilState(articlesFilterState);
+  const setFilter = useSetRecoilState(articlesFilterAtom);
   const navigate = useNavigate();
 
   const location = useLocation();

--- a/src/components/search/TitleSearch.jsx
+++ b/src/components/search/TitleSearch.jsx
@@ -1,31 +1,42 @@
-import React, { useState } from 'react';
-import { TextField } from '@mui/material';
-import styled from 'styled-components';
-import StyledForm from './StyledForm';
+import React, { useState } from "react";
+import { TextField } from "@mui/material";
+import styled from "styled-components";
+import StyledForm from "./StyledForm";
+import { useSetRecoilState } from "recoil";
+import { useLocation, useNavigate } from "react-router-dom";
+import { articlesFilterState } from "../../atom/articleAtom";
 
-const TitleSearch = ({ onSubmitInput }) => {
-    const [input, setInput] = useState();
+const TitleSearch = (props) => {
+  const [input, setInput] = useState();
+  const setFilter = useSetRecoilState(articlesFilterState);
+  const navigate = useNavigate();
 
-    return (
-        <StyledForm
-            onSubmit={(e) => {
-                e.preventDefault();
-                onSubmitInput && onSubmitInput(input);
-            }}
-        >
-            <StyledTextField
-                label="제목 검색"
-                type="search"
-                onChange={(e) => {
-                    setInput(e.target.value);
-                }}
-            />
-        </StyledForm>
-    );
+  const location = useLocation();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setFilter(input.trim());
+
+    if (location.pathname === "/home") {
+      navigate("/archive");
+    }
+  };
+
+  return (
+    <StyledForm onSubmit={handleSubmit}>
+      <StyledTextField
+        label="제목 검색"
+        type="search"
+        onChange={(e) => {
+          setInput(e.target.value);
+        }}
+      />
+    </StyledForm>
+  );
 };
 
 const StyledTextField = styled(TextField)`
-    width: 100%;
+  width: 100%;
 `;
 
 export default TitleSearch;

--- a/src/pages/ArchivePage.jsx
+++ b/src/pages/ArchivePage.jsx
@@ -47,7 +47,7 @@ const ArchivePage = (props) => {
         <>
           <SearchForm />
           {filteredArticles.length !== 0 ? (
-            <ProductCardList cardData={filteredArticles.articles} />
+            <ProductCardList cardData={filteredArticles} />
           ) : (
             <>
               <h3>

--- a/src/pages/ArchivePage.jsx
+++ b/src/pages/ArchivePage.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
 import {
-  articlesState,
-  articlesFilterState,
+  articlesAtom,
+  articlesFilterAtom,
   filteredArticlesSelector,
 } from "../atom/articleAtom.js";
 
@@ -14,8 +14,8 @@ import BannerCarousel, {
 import ProductCardList from "../components/card/ProductCardList";
 
 const ArchivePage = (props) => {
-  const articles = useRecoilValue(articlesState);
-  const filter = useRecoilValue(articlesFilterState);
+  const articles = useRecoilValue(articlesAtom);
+  const filter = useRecoilValue(articlesFilterAtom);
   const filteredArticles = useRecoilValue(filteredArticlesSelector);
 
   // const handleSubmitTag = (newTagList) => {

--- a/src/pages/ArchivePage.jsx
+++ b/src/pages/ArchivePage.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
 import {
-  articleSelector,
+  articlesSelector,
   articlesFilterState,
-  filteredArtcilesSelector,
+  filteredArticlesSelector,
 } from "../atom/articleAtom.js";
 
 import PageTemplate from "../template/PageTemplate";
@@ -14,9 +14,9 @@ import BannerCarousel, {
 import ProductCardList from "../components/card/ProductCardList";
 
 const ArchivePage = (props) => {
-  const articles = useRecoilValue(articleSelector);
+  const articles = useRecoilValue(articlesSelector);
   const filter = useRecoilValue(articlesFilterState);
-  const filteredArticles = useRecoilValue(filteredArtcilesSelector);
+  const filteredArticles = useRecoilValue(filteredArticlesSelector);
 
   // const handleSubmitTag = (newTagList) => {
   //   /**

--- a/src/pages/ArchivePage.jsx
+++ b/src/pages/ArchivePage.jsx
@@ -1,6 +1,10 @@
 import React from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
-import { articleSelector, filteredArticlesAtom } from "../atom/articleAtom.js";
+import { useRecoilValue } from "recoil";
+import {
+  articleSelector,
+  articlesFilterState,
+  filteredArtcilesSelector,
+} from "../atom/articleAtom.js";
 
 import PageTemplate from "../template/PageTemplate";
 import SearchForm from "../components/search/SearchForm";
@@ -11,72 +15,47 @@ import ProductCardList from "../components/card/ProductCardList";
 
 const ArchivePage = (props) => {
   const articles = useRecoilValue(articleSelector);
-  const [filteredArticles, setFilteredArticles] =
-    useRecoilState(filteredArticlesAtom);
+  const filter = useRecoilValue(articlesFilterState);
+  const filteredArticles = useRecoilValue(filteredArtcilesSelector);
 
-  const handleSubmitInput = (newInputValue) => {
-    const filteredArticles = articles.filter(({ title }) =>
-      title.includes(newInputValue)
-    );
-    if (newInputValue && newInputValue.trim() !== "") {
-      setFilteredArticles((oldState) => ({
-        ...oldState,
-        keyword: newInputValue,
-        articles: filteredArticles,
-      }));
-    } else {
-      setFilteredArticles((oldState) => ({
-        ...oldState,
-        keyword: null,
-        articles: [],
-      }));
-    }
-  };
-
-  const handleSubmitTag = (newTagList) => {
-    /**
-     * @TODO
-     * 태그 검색 구현 필요함
-     */
-    const filteredArticles = articles.filter(({ hashtagList }) => {
-      newTagList.forEach((tag) => {
-        if (!hashtagList.includes(tag)) {
-          return false;
-        }
-      });
-      return true;
-    });
-    if (filteredArticles.length === 0) {
-      setFilteredArticles((oldState) => ({ ...oldState, articles: [] }));
-    } else {
-      setFilteredArticles((oldState) => ({
-        ...oldState,
-        articles: filteredArticles,
-      }));
-    }
-  };
+  // const handleSubmitTag = (newTagList) => {
+  //   /**
+  //    * @TODO
+  //    * 태그 검색 구현 필요함
+  //    */
+  //   const filteredArticles = articles.filter(({ hashtagList }) => {
+  //     newTagList.forEach((tag) => {
+  //       if (!hashtagList.includes(tag)) {
+  //         return false;
+  //       }
+  //     });
+  //     return true;
+  //   });
+  //   if (filteredArticles.length === 0) {
+  //     setFilteredArticles((oldState) => ({ ...oldState, articles: [] }));
+  //   } else {
+  //     setFilteredArticles((oldState) => ({
+  //       ...oldState,
+  //       articles: filteredArticles,
+  //     }));
+  //   }
+  // };
 
   return (
     <PageTemplate
       contents={
         <>
-          <SearchForm
-            articles={articles.articles}
-            tagList={["컴퓨터공학과", "태그1", "태그2"]}
-            onSubmitInput={handleSubmitInput}
-            onSubmitTag={handleSubmitTag}
-          />
-          {filteredArticles.articles.length === 0 &&
-            filteredArticles.keyword !== null && (
-              <h3>
-                '{filteredArticles.keyword}'와(과) 일치하는 검색결과가 없습니다.
-                아래의 게시물들은 어떠신가요?
-              </h3>
-            )}
-          {filteredArticles.articles.length !== 0 ? (
+          <SearchForm />
+          {filteredArticles.length !== 0 ? (
             <ProductCardList cardData={filteredArticles.articles} />
           ) : (
-            <ProductCardList cardData={articles} />
+            <>
+              <h3>
+                '{filter}'와(과) 일치하는 검색결과가 없습니다. 아래의 게시물들은
+                어떠신가요?
+              </h3>
+              <ProductCardList cardData={articles} />
+            </>
           )}
         </>
       }

--- a/src/pages/ArchivePage.jsx
+++ b/src/pages/ArchivePage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
 import {
-  articlesSelector,
+  articlesState,
   articlesFilterState,
   filteredArticlesSelector,
 } from "../atom/articleAtom.js";
@@ -14,7 +14,7 @@ import BannerCarousel, {
 import ProductCardList from "../components/card/ProductCardList";
 
 const ArchivePage = (props) => {
-  const articles = useRecoilValue(articlesSelector);
+  const articles = useRecoilValue(articlesState);
   const filter = useRecoilValue(articlesFilterState);
   const filteredArticles = useRecoilValue(filteredArticlesSelector);
 

--- a/src/pages/EditPage.jsx
+++ b/src/pages/EditPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { selectedArticleSelector } from "../atom/articleAtom";
+import { curruntArticleSelector } from "../atom/articleAtom";
 import { userSelector } from "../atom/userAtom";
 import BackButton from "../components/common/BackButton";
 import EditForm from "../components/edit/EditForm";
@@ -18,7 +18,7 @@ const EditPage = () => {
   const id = searchParams.get("id");
   const EDIT_MODE = id ? "patch" : "post";
 
-  const article = useRecoilValue(selectedArticleSelector(id));
+  const article = useRecoilValue(curruntArticleSelector(id));
   const user = useRecoilValue(userSelector);
   const navigate = useNavigate();
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import { articleSelector } from "../atom/articleAtom";
+import { articlesSelector } from "../atom/articleAtom";
 
 import BannerCarousel, { itemsForHomePage } from "../components/BannerCarousel";
 import ProductCardList from "../components/card/ProductCardList";
@@ -10,7 +10,7 @@ import SearchForm from "../components/search/SearchForm";
 import PageTemplate from "../template/PageTemplate";
 
 const HomePage = (props) => {
-  const articles = useRecoilValue(articleSelector);
+  const articles = useRecoilValue(articlesSelector);
 
   /**
    * 공지는 가이드로 분류합니다.

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import { articlesState } from "../atom/articleAtom";
+import { articlesAtom } from "../atom/articleAtom";
 
 import BannerCarousel, { itemsForHomePage } from "../components/BannerCarousel";
 import ProductCardList from "../components/card/ProductCardList";
@@ -10,7 +10,7 @@ import SearchForm from "../components/search/SearchForm";
 import PageTemplate from "../template/PageTemplate";
 
 const HomePage = (props) => {
-  const articles = useRecoilValue(articlesState);
+  const articles = useRecoilValue(articlesAtom);
 
   /**
    * 공지는 가이드로 분류합니다.

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import { articleSelector, filteredArticlesAtom } from "../atom/articleAtom";
+import { articleSelector } from "../atom/articleAtom";
 
 import BannerCarousel, { itemsForHomePage } from "../components/BannerCarousel";
 import ProductCardList from "../components/card/ProductCardList";
@@ -12,29 +11,6 @@ import PageTemplate from "../template/PageTemplate";
 
 const HomePage = (props) => {
   const articles = useRecoilValue(articleSelector);
-  const setFilteredArticles = useSetRecoilState(filteredArticlesAtom);
-  const navigate = useNavigate();
-
-  // ArchivePage의 handleSubmitInput와 중복됨
-  const handleSubmitInput = (newInputValue) => {
-    const filteredArticles = articles.filter(({ title }) =>
-      title.includes(newInputValue)
-    );
-    if (newInputValue && newInputValue.trim() !== "") {
-      setFilteredArticles((oldState) => ({
-        ...oldState,
-        keyword: newInputValue,
-        articles: filteredArticles,
-      }));
-    } else {
-      setFilteredArticles((oldState) => ({
-        ...oldState,
-        keyword: null,
-        articles: [],
-      }));
-    }
-    navigate("/archive");
-  };
 
   /**
    * 공지는 가이드로 분류합니다.
@@ -51,7 +27,7 @@ const HomePage = (props) => {
     <PageTemplate
       contents={
         <StyledHomePage>
-          <SearchForm onSubmitInput={handleSubmitInput} />
+          <SearchForm />
           <div className="ScollList-container">
             <h1 className={"title"}>컴퓨터 공학과 전시회</h1>
             <ScrollList>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import { articlesSelector } from "../atom/articleAtom";
+import { articlesState } from "../atom/articleAtom";
 
 import BannerCarousel, { itemsForHomePage } from "../components/BannerCarousel";
 import ProductCardList from "../components/card/ProductCardList";
@@ -10,7 +10,7 @@ import SearchForm from "../components/search/SearchForm";
 import PageTemplate from "../template/PageTemplate";
 
 const HomePage = (props) => {
-  const articles = useRecoilValue(articlesSelector);
+  const articles = useRecoilValue(articlesState);
 
   /**
    * 공지는 가이드로 분류합니다.

--- a/src/pages/ProjectDetailPage.jsx
+++ b/src/pages/ProjectDetailPage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
-import { selectedArticleSelector } from "../atom/articleAtom.js";
+import { curruntArticleSelector } from "../atom/articleAtom.js";
 
 // components import
 import PageTemplate from "../template/PageTemplate";
@@ -17,7 +17,7 @@ import useLogin from "../hooks/useLogin.js";
 const ProjectDetailPage = (props) => {
   let { id } = useParams();
   const { fetchUserInfo } = useLogin();
-  const article = useRecoilValue(selectedArticleSelector(id));
+  const article = useRecoilValue(curruntArticleSelector(id));
 
   useEffect(() => {
     (async () => {
@@ -42,7 +42,7 @@ const MainContents = ({ article }) => {
         src={article.thumbnail || `https://via.placeholder.com/690x400`}
         alt="post-thumbnail"
       />
-      <ProjectInfoBox articleId={article.id} />
+      <ProjectInfoBox article={article} />
       <Paper elevation={5} sx={{ mt: 3, mb: 8, p: 5, borderRadius: 8 }}>
         <TextViewer data={article.content} />
       </Paper>


### PR DESCRIPTION
## 작업내용
Issue: #76 이슈 중, articleAtom.js의 article 관련 코드를 수정하였습니다.
- `articleAtom`을 `articlesAtom`으로 네이밍 수정
- 검색창 submit handler의 코드가 ArchaivePage, HomePage에서 중복되는 문제 해결
- 키워드 검색 submit시, 필터 State를 활용해 articles를 필터링해 반환하는 Selector를 구현 ==> submit handler 코드 추상화, 단순해짐

## 레퍼런스
- [ArticlesAtom의 default에 바로 articles 배열을 저장](https://www.notion.so/ArticlesAtom-default-articles-6097e270d8584011b2f252ee6023a199)
- [게시글 제목 검색 상태관리 개선](https://www.notion.so/a0f1ba4e0cd14c0cb4cde5a6df6cf74b)


## check📝
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?